### PR TITLE
Changed indexing for converting vector to matrix

### DIFF
--- a/R/depth.adj.R
+++ b/R/depth.adj.R
@@ -33,6 +33,7 @@
 
 depth.adj = function(d, size, resol, out = 0){
 
+    min = d[1,3]
     cd = d[,-c(1,2,3)]
     rownames(cd) = colnames(cd) = d[,3]-resol/2
 
@@ -49,8 +50,8 @@ depth.adj = function(d, size, resol, out = 0){
     ##turn it back to matrix
 
     ntemp = temp[which(temp[,3]!=0),]
-    ntemp[,1] = (ntemp[,1]+resol/2)/resol
-    ntemp[,2] = (ntemp[,2]+resol/2)/resol
+    ntemp[,1] = (ntemp[,1] + resol/2 - min)/resol + 1
+    ntemp[,2] = (ntemp[,2] + resol/2 - min)/resol + 1
     cd[cd>0] = 0
     cd[ntemp[,c(1,2)]] = ntemp[,3]
 

--- a/R/depth.adj.R
+++ b/R/depth.adj.R
@@ -33,7 +33,7 @@
 
 depth.adj = function(d, size, resol, out = 0){
 
-    min = d[1,3]
+    min = d[1,3]	#minimum genomic coordinate
     cd = d[,-c(1,2,3)]
     rownames(cd) = colnames(cd) = d[,3]-resol/2
 
@@ -50,8 +50,8 @@ depth.adj = function(d, size, resol, out = 0){
     ##turn it back to matrix
 
     ntemp = temp[which(temp[,3]!=0),]
-    ntemp[,1] = (ntemp[,1] + resol/2 - min)/resol + 1
-    ntemp[,2] = (ntemp[,2] + resol/2 - min)/resol + 1
+    ntemp[,1] = (ntemp[,1] + resol/2 - min)/resol + 1	#new indexing (add 1 because 1-indexed)
+    ntemp[,2] = (ntemp[,2] + resol/2 - min)/resol + 1	#new indexing (add 1 because 1-indexed)
     cd[cd>0] = 0
     cd[ntemp[,c(1,2)]] = ntemp[,3]
 

--- a/R/get.scc.R
+++ b/R/get.scc.R
@@ -78,7 +78,7 @@ get.scc <- function (dat, resol, max){
     corr = corr0[!is.na(corr0)]
     wei = wei0[!is.na(wei0)]
     scc = corr %*% wei/sum(wei)
-    std = sqrt(sum(wei^2*(1-corr^2)^2/(n-3))/(sum(wei))^2)
+    std = sqrt(sum(wei^2*(1-corr^2)^2/c(n-3))/(sum(wei))^2)
   
     return(list(corr = corr, wei = wei, scc = scc, std = std))
 }


### PR DESCRIPTION
depth.adj.R was producing an error that seemed to be due to the chromosome not starting at coordinate 0. I have attempted to make changes that will give the correct indexing regardless of chromosome start. (See comments in file.) The code has worked in my testing, but please review to make sure I understood the behavior of the script correctly. 