### PR TITLE
🐛 Fix a critical bug in hic2mat/bed2mat

### DIFF
--- a/R/bed2mat.R
+++ b/R/bed2mat.R
@@ -28,11 +28,11 @@
 bed2mat <- function(bed, resol = "NONE"){ 
   # n the max number of bin
   if (resol == "NONE") {
-    N = max(bed[,c(1:2)])
+    N = max(bed[,c(1:2)]) + 1
   } else {
-    N = max(bed[,c(1:2)])/resol
-    bed[,1] = bed[,1]/resol
-    bed[,2] = bed[,2]/resol
+    N = max(bed[,c(1:2)])/resol + 1
+    bed[,1] = bed[,1]/resol + 1
+    bed[,2] = bed[,2]/resol + 1
   }
   
   mat = matrix(0, N, N)


### PR DESCRIPTION
This bug leads to an incorrectly shifted Hi-C matrix.

In the code base, the only place where `bed2mat` is invoked is within `hic2mat` (https://github.com/MonkeyLB/hicrep/blob/master/R/hic2mat.R#L25). `hic2mat` first convert the .hic file to a BED-like data frame (via `strawr::straw`), then `bed2mat` takes over and calculates the R matrix that meets hicrep input format requirements.

However, the output of `strawr:straw` is a BED-like structure as follows (the bin size in this example is 500kb):

```
        x       y counts
1       0       0    442
2       0  500000     16
3  500000  500000    441
4       0 1000000     11
5  500000 1000000     46
6 1000000 1000000    452
```

`strawr::straw` denotes the "first bin" as 0. Therefore, during the conversion, the correct way of dealing with subscripts is shown here in this pull request.